### PR TITLE
improve our team page formatting

### DIFF
--- a/book/team.md
+++ b/book/team.md
@@ -1,23 +1,28 @@
-# Contributors ✨
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+# Our Team
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+````{panels}
+:column: col-4
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="http://scottyhq.github.io"><img src="https://avatars.githubusercontent.com/u/3924836?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Scott Henderson</b></sub></a><br /><a href="#eventOrganizing-scottyhq" title="Event Organizing">📋</a></td>
-    <td align="center"><a href="http://psc.apl.uw.edu/people/investigators/anthony-arendt/"><img src="https://avatars.githubusercontent.com/u/4993098?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anthony Arendt</b></sub></a><br /><a href="#eventOrganizing-aaarendt" title="Event Organizing">📋</a> <a href="#ideas-aaarendt" title="Ideas, Planning, & Feedback">🤔</a> <a href="#content-aaarendt" title="Content">🖋</a></td>
-  </tr>
-</table>
+**Scott Henderson**
+^^^
+<img src="https://avatars.githubusercontent.com/u/3924836?v=4?s=100">
++++
+Ask me about: InSAR, Jupyter, Python
+---
 
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
+**Anthony Arendt**
+^^^
+<img src="https://avatars.githubusercontent.com/u/4993098?v=4?s=100">
++++
+Ask me about: Hackweeks, Glaciers, Python
+---
 
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+**Landung "Don" Setiawan**
+^^^
+<img src="https://avatars.githubusercontent.com/u/17802172?v=4?s=100">
++++
+Ask me about: Oceanography, Python
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+````
+
+Note: to add additional people to the team, you can easily get the URL of a GitHub user image via the following link https://api.github.com/users/GITHUB_USERNAME

--- a/book/team.md
+++ b/book/team.md
@@ -25,4 +25,4 @@ Ask me about: Oceanography, Python
 
 ````
 
-Note: to add additional people to the team, you can easily get the URL of a GitHub user image via the following link https://api.github.com/users/GITHUB_USERNAME
+Note: to add additional people to the team, you can easily get the URL of a GitHub user image via the GitHub API: `https://api.github.com/users/GITHUB_USERNAME`

--- a/book/team.md
+++ b/book/team.md
@@ -1,5 +1,7 @@
 # Our Team
 
+The people on this page have helped organize the hackweek. You'll find a few specializations listed per person if you're wondering who to reach out to during the event!
+
 ````{panels}
 :column: col-4
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 services:
-  pangeo-notebook:
+  jupyterlab:
     image: "uwhackweek/template:latest"
     ports:
       - "8888:8888"


### PR DESCRIPTION
the all-contributors bot formats nicely for a readme, but not really for jupyter-book unless there are tons of contributors https://github.com/uwhackweek/jupyterbook-template#contributors- 

virtual hackweeks benefit from having an easy reference for tutorial leads and organizers to know who to ask, which is the intention of the team.md page using jupyterbook 'panels' formatting:

https://jupyterbook.org/content/content-blocks.html#panels 

A neat activity to get *participants* acquainted with github and git, could be to create a 'participants.md' page and have them create a PR to add themselves to the list... 