### PR TITLE
bump to jupyter-book 0.11.3, change TOC

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -1,7 +1,9 @@
 # Table of content
 # Learn more at https://jupyterbook.org/customize/toc.html
-- file: intro
-- part: Details
+root: intro
+format: jb-book
+parts:
+- caption: Details
   chapters:
   - file: application
   - file: schedule
@@ -10,7 +12,7 @@
     sections:
     - file: norms/CoC
     - file: norms/community
-- part: Preparation
+- caption: Preparation
   chapters:
     - file: preliminary/index
       sections:
@@ -21,7 +23,7 @@
         - file: preliminary/earthdata
         - file: preliminary/pangeo
         - file: preliminary/python
-- part: Tutorials
+- caption: Tutorials
   chapters:
     - file: tutorials/index
       sections:
@@ -30,14 +32,14 @@
         - file: tutorials/open_science
         - file: tutorials/open_source_software
         - file: tutorials/example/intro_ipyleaflet
-- part: Projects
+- caption: Projects
   chapters:
     - file: projects/index
       sections:
         - file: projects/project_initialization
         - file: projects/project_roles
         - file: projects/list_of_projects
-- part: Reference
+- caption: Reference
   chapters:
     - file: glossary
     - file: bibliography


### PR DESCRIPTION
Copying what @scottyhq just did in [PR12 for the UW hackweek book](https://github.com/uwhackweek/hackweeks-as-a-service/pull/12), following [this blog](https://executablebooks.org/en/latest/updates/2021-06-18-update-toc.html) to migrate TOC to 0.11.3.