### PR TITLE
streamline book building with a single action with boolean flags

### DIFF
--- a/.github/actions/buildbook/action.yml
+++ b/.github/actions/buildbook/action.yml
@@ -21,10 +21,10 @@ runs:
     - name: Setup JupyterBook Cache
       if: ${{inputs.jb-cache}} == true
       uses: actions/cache@v2
-      # NOTE: change key to "jupyterbook-N+1" to force rebuilding cache
       with:
         path: ./book/_build
-        key: jupyterbook
+        # NOTE: change key to "jupyterbook-N+1" to force rebuilding cache
+        key: jupyterbook-0
 
     - uses: ./.github/actions/setupconda
 

--- a/.github/actions/buildbook/action.yml
+++ b/.github/actions/buildbook/action.yml
@@ -1,0 +1,48 @@
+name: 'Build Jupyterbook'
+description: 'Build the Jupyterbook with desired run features'
+
+inputs:
+  jb-cache:
+    description: “Set up the Jupyterbook Cache (boolean)”
+    required: true
+  publish-to-gh:
+    description: “Publish to GitHub Pages (boolean)”
+    required: true
+  jb-save:
+    description: "Save the Jupyterbook Build (boolean)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup JupyterBook Cache
+      if: ${{inputs.jb-cache}} == true
+      uses: actions/cache@v2
+      # NOTE: change key to "jupyterbook-N+1" to force rebuilding cache
+      with:
+        path: ./book/_build
+        key: jupyterbook
+
+    - uses: ./.github/actions/setupconda
+
+    - name: Build JupyterBook
+      run: |
+        jb build book
+
+    - name: Publish to GitHub Pages
+      if: ${{inputs.publish-to-gh}} == true
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        personal_token: ${{ secrets.GH_PAT }}
+        publish_dir: book/_build/html
+        publish_branch: gh-pages
+
+    - name: Save Build
+      if: ${{inputs.jb-save}} == true}} and ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: book/_build/

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -14,25 +14,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Setup JupyterBook Cache
-      uses: actions/cache@v2
-      # NOTE: change key to "jupyterbook-N+1" to force rebuilding cache
+    - uses: ./.github/actions/buildbook
       with:
-        path: ./book/_build
-        key: jupyterbook
-
-    - uses: ./.github/actions/setupconda
-
-    - name: Build JupyterBook
-      run: |
-        jb build book
-
-    - name: Save Build
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: build
-        path: book/_build/
+        jb-cache: true
+        publish-to-gh: false
+        jb-save: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,31 +16,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup JupyterBook Cache
-      uses: actions/cache@v2
-      # NOTE: change key "jupyterbook-N+1" to force rebuilding cache
+    - uses: ./.github/actions/buildbook
       with:
-        path: ./book/_build
-        key: jupyterbook
-
-    - uses: ./.github/actions/setupconda
-
-    - name: Build JupyterBook
-      run: |
-        jb build book
-
-    - name: Publish to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        personal_token: ${{ secrets.GH_PAT }}
-        publish_dir: book/_build/html
-        publish_branch: gh-pages
-
-    - name: Save Build
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: build
-        path: book/_build/
+        jb-cache: true
+        publish-to-gh: true
+        jb-save: true

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -5,6 +5,7 @@ on: workflow_dispatch
     # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-workflow-configuration
   paths:
     - '.github/workflows/manual.yaml'
+
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
     # can maybe specify PR branch ref here?
     # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-workflow-configuration
-    paths:
-      - '.github/workflows/manual.yaml'
 
 jobs:
   build-and-test:

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -12,18 +12,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - uses: ./.github/actions/setupconda
-
-    - name: Build JupyterBook
-      run: |
-        jb build book
-
-    - name: Save Build
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+    - uses: ./.github/actions/buildbook
       with:
-        name: build
-        path: book/_build/
+        jb-cache: false
+        publish-to-gh: false
+        jb-save: true

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -3,7 +3,8 @@ name: Build Without Cache
 on: workflow_dispatch
     # can maybe specify PR branch ref here?
     # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-workflow-configuration
-
+  paths:
+    - '.github/workflows/manual.yaml'
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
@@ -12,7 +13,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: ../.github/actions/buildbook
+    - uses: ./.github/actions/buildbook
       with:
         jb-cache: false
         publish-to-gh: false

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -1,10 +1,11 @@
 name: Build Without Cache
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
     # can maybe specify PR branch ref here?
     # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-workflow-configuration
-  paths:
-    - '.github/workflows/manual.yaml'
+    paths:
+      - '.github/workflows/manual.yaml'
 
 jobs:
   build-and-test:

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -12,7 +12,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: ./.github/actions/buildbook
+    - uses: ../.github/actions/buildbook
       with:
         jb-cache: false
         publish-to-gh: false

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -15,23 +15,11 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
 
     steps:
-    - name: Checkout PR
-      uses: actions/checkout@v2
+    - uses: ./.github/actions/buildbook
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Setup JupyterBook Cache
-      uses: actions/cache@v2
-      # NOTE: change key to "jupyterbook-N+1" to force rebuilding cache
-      with:
-        path: ./book/_build
-        key: jupyterbook
-
-    - uses: ./.github/actions/setupconda
-
-    - name: Build JupyterBook
-      run: |
-        jb build book
+        jb-cache: true
+        publish-to-gh: false
+        jb-save: false
 
     - name: Deploy Website Preview
       uses: nwtgck/actions-netlify@v1.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,26 +21,8 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'preview')
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: ./.github/actions/buildbook
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Setup JupyterBook Cache
-      uses: actions/cache@v2
-      # NOTE: change key to "jupyterbook-N+1" to force rebuilding cache
-      with:
-        path: ./book/_build
-        key: jupyterbook
-
-    - uses: ./.github/actions/setupconda
-
-    - name: Build JupyterBook
-      run: |
-        jb build book
-
-    - name: Save Build
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: build
-        path: book/_build/
+        jb-cache: true
+        publish-to-gh: false
+        jb-save: true


### PR DESCRIPTION
Trying to build on #29 to streamline actions. This creates a generic build jupyterbook action with booleans to run various steps (caching, github pages publishing, saving) based on input flags. Thus we can customize the run types (cron, manual, deploy, etc.) but control the building from one place.

Closes #17 