### PR TITLE
no default shell in composite actions

### DIFF
--- a/.github/actions/buildbook/action.yml
+++ b/.github/actions/buildbook/action.yml
@@ -11,6 +11,9 @@ inputs:
   jb-save:
     description: "Save the Jupyterbook Build (boolean)"
     required: true
+  token:
+    description: 'A GitHub Personal Access Token (for publishing)'
+    required: false
 
 runs:
   using: "composite"
@@ -34,7 +37,7 @@ runs:
       if: ${{inputs.publish-to-gh}} == true
       uses: peaceiris/actions-gh-pages@v3
       with:
-        personal_token: ${{ secrets.GH_PAT }}
+        personal_token: ${{inputs.token}}
         publish_dir: book/_build/html
         publish_branch: gh-pages
 

--- a/.github/actions/buildbook/action.yml
+++ b/.github/actions/buildbook/action.yml
@@ -15,9 +15,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
     - name: Setup JupyterBook Cache
       if: ${{inputs.jb-cache}} == true
       uses: actions/cache@v2
@@ -29,6 +26,7 @@ runs:
     - uses: ./.github/actions/setupconda
 
     - name: Build JupyterBook
+      shell: bash -l {0}
       run: |
         ./scripts/deploy_website.sh
 

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,14 +9,11 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      
+
     - uses: ./.github/actions/buildbook
       with:
         jb-cache: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,14 +11,11 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      
+
     - uses: ./.github/actions/buildbook
       with:
         jb-cache: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,3 +21,4 @@ jobs:
         jb-cache: true
         publish-to-gh: true
         jb-save: true
+        token:  ${{ secrets.GH_PAT }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,10 @@ on:
   push:
     paths:
       - 'book/**'
+      - '{{ cookiecutter.repo_directory }}/**'
+      - 'scripts/**'
       - '.github/workflows/deploy.yaml'
+
     branches:
       - main
 

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -8,14 +8,11 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      
+
     - uses: ./.github/actions/buildbook
       with:
         jb-cache: false

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -2,8 +2,6 @@ name: Build Without Cache
 
 on:
   workflow_dispatch:
-    # can maybe specify PR branch ref here?
-    # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-workflow-configuration
 
 jobs:
   build-and-test:

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -7,9 +7,6 @@ on:
 jobs:
   add-preview:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash -l {0}
     # This workflow accesses secrets and checks out a PR, so only run if labelled
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     if: contains(github.event.pull_request.labels.*.name, 'preview')
@@ -17,7 +14,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      
+
     - uses: ./.github/actions/buildbook
       with:
         jb-cache: true

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -36,6 +36,7 @@ jobs:
         check_filenames: true
         check_hidden: true
         only_warn: false
+        skip: *.js
 
     # borrowed from https://github.com/ProjectPythia/pythia-foundations/blob/main/.github/workflows/link-checker.yaml
     - name: Disable Notebook Execution

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'book/**'
+      - '{{ cookiecutter.repo_directory }}/**'
+      - 'scripts/**'
       - '.github/workflows/qaqc.yaml'
     branches:
       - main

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -36,7 +36,7 @@ jobs:
         check_filenames: true
         check_hidden: true
         only_warn: false
-        skip: *.js
+        skip: '*.js'
 
     # borrowed from https://github.com/ProjectPythia/pythia-foundations/blob/main/.github/workflows/link-checker.yaml
     - name: Disable Notebook Execution

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,6 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
-    # This workflow accesses secrets and checks out a PR, so only run if labelled
-    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-    if: contains(github.event.pull_request.labels.*.name, 'preview')
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'book/**'
       - '.github/workflows/test.yaml'
+      - '{{ cookiecutter.repo_directory }}/**'
+      - 'scripts/**'
       - 'binder/**'
     branches:
       - main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   pull_request_target:
-    types: [labeled, synchronize]
     paths:
       - 'book/**'
       - '.github/workflows/test.yaml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,6 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash -l {0}
     # This workflow accesses secrets and checks out a PR, so only run if labelled
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     if: contains(github.event.pull_request.labels.*.name, 'preview')
@@ -23,7 +20,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      
+
     - uses: ./.github/actions/buildbook
       with:
         jb-cache: true


### PR DESCRIPTION
Follow-on to #42

Any 'run' command in github actions needs the shell type (bash) specified
https://github.com/actions/runner/issues/646#issuecomment-676479174 


Also need to pass secrets as inputs (https://stackoverflow.com/questions/70098241/using-secrets-in-composite-actions-github)