### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+# https://EditorConfig.org
+
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.ipynb]
+# Content is json, but it seems to be minimally formatted
+indent_size = unset
+
+[{*.json,.ecrc}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[make.bat]
+end_of_line = crlf
+indent_style = tab
+
+[*.md]
+indent_size = unset
+
+[{*.py,setup.cfg}]
+# yapf and black will use indents other than 4 spaces
+indent_size = unset
+
+[*.rst]
+indent_size = unset
+
+[*.yml]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = 4
 # Content is json, but it seems to be minimally formatted
 indent_size = unset
 
+[*.js]
+indent_size = 2
+
 [*.json]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,25 +15,18 @@ indent_size = 4
 # Content is json, but it seems to be minimally formatted
 indent_size = unset
 
-[{*.json,.ecrc}]
+[*.json]
 indent_size = 2
-
-[Makefile]
-indent_style = tab
-
-[make.bat]
-end_of_line = crlf
-indent_style = tab
 
 [*.md]
 indent_size = unset
 
-[{*.py,setup.cfg}]
+[*.py]
 # yapf and black will use indents other than 4 spaces
 indent_size = unset
 
 [*.rst]
 indent_size = unset
 
-[*.yml]
+[{*.yml, *.yaml}]
 indent_size = 2


### PR DESCRIPTION
Addresses #47 

We could customize this a bit, I took it straight from https://github.com/stactools-packages/template/blob/main/.editorconfig

While many commonly used text editors will pick up settings from this file automatically, others need to install a plugin https://editorconfig.org/#pre-installed