### PR TITLE
GH actions - Try to address case-insensitive OS

### DIFF
--- a/.github/actions/setupconda/action.yml
+++ b/.github/actions/setupconda/action.yml
@@ -19,6 +19,6 @@ runs:
       with:
         miniforge-version: latest
         auto-update-conda: false
-        environment-file: conda/conda-${{ runner.os }}-64.lock
+        environment-file: conda/conda-${{ runner.os == 'Linux' && 'linux' || 'osx'  }}-64.lock
         activate-environment: hackweek
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!

--- a/conda/conda-Linux-64.lock
+++ b/conda/conda-Linux-64.lock
@@ -1,1 +1,0 @@
-conda-linux-64.lock

--- a/conda/conda-macos-64.lock
+++ b/conda/conda-macos-64.lock
@@ -1,1 +1,0 @@
-conda-osx-64.lock

--- a/conda/lock-environment.sh
+++ b/conda/lock-environment.sh
@@ -25,13 +25,6 @@ fi
 # Local environments
 ## Generate explicit lock files (optional -p win-64)
 conda-lock lock --mamba -f ${ENV_FILE} -p linux-64 -p osx-64
-# The symbolic link is needed to test GitHub actions.
-if [[ ! -L "conda-macos-64.lock" ]]; then
-  ln -s conda-osx-64.lock conda-macos-64.lock
-fi
-if [[ ! -L "conda-Linux-64.lock" ]]; then
-  ln -s conda-linux-64.lock conda-Linux-64.lock
-fi
 
 # BinderHub support
 ## Generate environment.yml for binder compatibility


### PR DESCRIPTION
Having a symbolic link in the repository that is only different from the
original file with a different case (linux vs Linux) causes issue on
platforms that do not have a case-sensitive file system (e.g. macOS,
Windows).

Fixes #52