### PR TITLE
Index - Add option for banner links

### DIFF
--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -17,8 +17,10 @@ banner:
   links:
   - url: '#'
     title: Event details coming soon
+    new_window: true
   - url: intro.html
     title: More info
+    new_window: false
   image: https://geohackweek.github.io/assets/images/banner.jpg
 applicant_info: UW Hackweek 2022 will take place in October 2022 (virtual or in-person
   TBD). Applications have not yet opened, but should be anticipated in September 2022.

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -122,7 +122,12 @@
 				{%- if cookiecutter.banner.links %}
 				<div class="hero-cta">
 					{%- for link in cookiecutter.banner.links %}
-					<a class="btn btn-primary btn-lg m-2" href="{{ link.url }}" target="_blank">{{ link.title }}</a>
+					<a class="btn btn-primary btn-lg m-2"
+					   href="{{ link.url }}"
+					   {{ 'target="_blank"' if link.new_window == 'True' else '' }}
+					>
+						{{ link.title }}
+					</a>
 					{%- endfor %}
 				</div>
 				{%- endif %}


### PR DESCRIPTION
Add an option to specify whether buttons in the banner should open a new
page or not.

Noticed in our meeting demo today,that the 'More Info' button opened a new tab each time. This is less desirable when we are navigating between index and the the book. So I made this an option when adding links to the banner