### PR TITLE
update jupyterbook toc links to splash pages

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -15,7 +15,7 @@ parse:
     github_org_url: "https://github.com/uwhackweek"
     book_repo: "jupyterbook-template"
     # website_url: "https://github.com/uwhackweek/website"
-    website_url: "https://uwhackweek.github.io"
+    website_url: "https://uwhackweek.github.io/jupyterbook-template"
     jupyterhub_url: INSERT_JUPYTERHUB_URL
     slack_workspace_url: INSERT_SLACK_URL
     docker_image: INSERT_DOCKER_IMAGE_URL

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -6,10 +6,10 @@ parts:
 - caption: Details
   chapters:
   - file: application
-  - url: https://uwhackweek.github.io/jupyterbook-template/#schedule-section
-    title: Schedule
-  - url: https://uwhackweek.github.io/jupyterbook-template/#team
-    title: Team
+  - title: Schedule
+    url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=team
+  - title: Team
+    url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=schedule
   - file: mission
   - file: CoC
 - caption: Preparation

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -7,9 +7,9 @@ parts:
   chapters:
   - file: application
   - title: Schedule
-    url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=team
-  - title: Team
     url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=schedule
+  - title: Team
+    url: https://uwhackweek.github.io/jupyterbook-template/index.html?jump_to=team
   - file: mission
   - file: CoC
 - caption: Preparation

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -6,9 +6,9 @@ parts:
 - caption: Details
   chapters:
   - file: application
-  - url: https://uwhackweek.github.io#schedule-section
+  - url: https://uwhackweek.github.io/jupyterbook-template/#schedule-section
     title: Schedule
-  - url: https://uwhackweek.github.io#team
+  - url: https://uwhackweek.github.io/jupyterbook-template/#team
     title: Team
   - file: mission
   - file: CoC

--- a/book/intro.md
+++ b/book/intro.md
@@ -8,9 +8,9 @@ On this JupyterBook website you will:
 
 {fa}`check,text-success mr-1`: learn about our hackweek [Mission](mission) and our [Code of Conduct](CoC)
 
-{fa}`check,text-success mr-1`: learn more about the amazing {{ '[organizing team]({url}/#team)'.format(url=website_url) }} who have designed this event
+{fa}`check,text-success mr-1`: learn more about the amazing {{ '[organizing team]({url}/index.html?jump_to=team)'.format(url=website_url) }} who have designed this event
 
-{fa}`check,text-success mr-1`: review the hackweek {{ '[schedule]({url}/#schedule-section)'.format(url=website_url) }}
+{fa}`check,text-success mr-1`: review the hackweek {{ '[schedule]({url}/index.html?jump_to=schedule)'.format(url=website_url) }}
 
 {fa}`check,text-success mr-1`: find out how you can submit an [application form](application)
 

--- a/{{ cookiecutter.repo_directory }}/assets/js/main.js
+++ b/{{ cookiecutter.repo_directory }}/assets/js/main.js
@@ -67,13 +67,7 @@ if (window.location.search.length > 1) {
 /* ===== Gumshoe SrollSpy ===== */
 /* Ref: https://github.com/cferdinandi/gumshoe  */
 // Get the sticky header
-
-
-// Initialize Gumshoe
-var spy = new Gumshoe('#navigation a', {
-  offset: 69 //page .header heights
-});
-
+const spy = new Gumshoe('#navigation a', { offset: yOffset });
 
 // variables for time units
 const counterDiv = document.getElementById("countdown-box");

--- a/{{ cookiecutter.repo_directory }}/assets/js/main.js
+++ b/{{ cookiecutter.repo_directory }}/assets/js/main.js
@@ -3,60 +3,48 @@
 /* ======= Header animation ======= */
 const header = document.getElementById('header');
 
-window.onload=function()
-{
-    headerAnimation();
+window.onload = function () {
+  headerAnimation();
 };
 
-window.onresize=function()
-{
-    headerAnimation();
+window.onresize = function () {
+  headerAnimation();
 };
 
-window.onscroll=function()
-{
-    headerAnimation();
+window.onscroll = function () {
+  headerAnimation();
 };
 
+function headerAnimation() {
+  const scrollTop = window.scrollY;
 
-function headerAnimation () {
-    var scrollTop = window.scrollY;
-
-	if ( scrollTop > 100 ) {
-	    header.classList.add('header-shrink');
-
-	} else {
-	    header.classList.remove('header-shrink');
-	}
+  if (scrollTop > 100) {
+    header.classList.add('header-shrink');
+  } else {
+    header.classList.remove('header-shrink');
+  }
 }
 
 /* ===== Smooth scrolling ====== */
-/*  Note: You need to include smoothscroll.min.js (smooth scroll behavior polyfill) on the page to cover some browsers */
-/* Ref: https://github.com/iamdustan/smoothscroll */
 
-
-let scrollLinks = document.querySelectorAll('.scrollto');
+const scrollLinks = document.querySelectorAll('.scrollto');
 const pageNavWrapper = document.getElementById('navigation');
 const yOffset = 69; //page .header height
 
 scrollLinks.forEach((scrollLink) => {
-	scrollLink.addEventListener('click', (e) => {
-		e.preventDefault();
+  scrollLink.addEventListener('click', (e) => {
+    e.preventDefault();
 
-		let element = document.querySelector(scrollLink.getAttribute("href"));
+    let element = document.querySelector(scrollLink.getAttribute("href"));
+    const y = element.getBoundingClientRect().top + window.pageYOffset - yOffset;
 
-		//console.log(yOffset);
+    window.scrollTo({top: y, behavior: 'smooth'});
 
-		const y = element.getBoundingClientRect().top + window.pageYOffset - yOffset;
-
-		window.scrollTo({top: y, behavior: 'smooth'});
-
-
-		//Collapse mobile menu after clicking
-		if (pageNavWrapper.classList.contains('show')){
-			pageNavWrapper.classList.remove('show');
-		}
-    });
+    //Collapse mobile menu after clicking
+    if (pageNavWrapper.classList.contains('show')) {
+      pageNavWrapper.classList.remove('show');
+    }
+  });
 });
 
 // Jump to section if requested via URL 'jump_to' parameter
@@ -83,63 +71,62 @@ if (window.location.search.length > 1) {
 
 // Initialize Gumshoe
 var spy = new Gumshoe('#navigation a', {
-	offset: 69 //page .header heights
+  offset: 69 //page .header heights
 });
 
 
 // variables for time units
-const counterDiv =  document.getElementById("countdown-box");
+const counterDiv = document.getElementById("countdown-box");
 const endDate = new Date(counterDiv.getAttribute('data-start-date'));
 let days, hours, minutes, seconds;
 
 function createCountdownSpans(className) {
-    const span = document.createElement("SPAN");
-    span.className = className;
-    return span
+  const span = document.createElement("SPAN");
+  span.className = className;
+  return span
 }
 
 function updateCountdownHTML(span, value, unit) {
-    span.innerHTML = '<span class="number">' + value + '</span>' +
-        '<span class="unit">' + unit + '</span>';
+  span.innerHTML = '<span class="number">' + value + '</span>' +
+    '<span class="unit">' + unit + '</span>';
 }
 
 function timeLeft() {
-    // find the amount of "seconds" between now and target
-    const currentDate = new Date().getTime();
-    return (endDate - currentDate) / 1000;
+  // find the amount of "seconds" between now and target
+  const currentDate = new Date().getTime();
+  return (endDate - currentDate) / 1000;
 }
 
-
 function updateCounter(counterDiv) {
-    let secondsLeft = timeLeft()
-    let days = parseInt(secondsLeft / 86400);
-    secondsLeft = secondsLeft % 86400;
+  let secondsLeft = timeLeft()
+  let days = parseInt(secondsLeft / 86400);
+  secondsLeft = secondsLeft % 86400;
 
-    let hours = parseInt(secondsLeft / 3600);
-    secondsLeft = secondsLeft % 3600;
+  let hours = parseInt(secondsLeft / 3600);
+  secondsLeft = secondsLeft % 3600;
 
-    let minutes = parseInt(secondsLeft / 60);
-    let seconds = parseInt(secondsLeft % 60);
+  let minutes = parseInt(secondsLeft / 60);
+  let seconds = parseInt(secondsLeft % 60);
 
-    // format countdown string + set tag value.
-    updateCountdownHTML(counterDiv.getElementsByClassName('days')[0], days, 'Days');
-    updateCountdownHTML(counterDiv.getElementsByClassName('hours')[0], hours, 'Hours');
-    updateCountdownHTML(counterDiv.getElementsByClassName('minutes')[0], minutes, 'Mins');
-    updateCountdownHTML(counterDiv.getElementsByClassName('secs')[0], seconds, 'Secs');
+  // format countdown string + set tag value.
+  updateCountdownHTML(counterDiv.getElementsByClassName('days')[0], days, 'Days');
+  updateCountdownHTML(counterDiv.getElementsByClassName('hours')[0], hours, 'Hours');
+  updateCountdownHTML(counterDiv.getElementsByClassName('minutes')[0], minutes, 'Mins');
+  updateCountdownHTML(counterDiv.getElementsByClassName('secs')[0], seconds, 'Secs');
 }
 
 function startCountDown(counterDiv) {
-    if ( timeLeft() > 0 ) {
-        counterDiv.appendChild(createCountdownSpans('days'))
-        counterDiv.appendChild(createCountdownSpans('hours'))
-        counterDiv.appendChild(createCountdownSpans('minutes'))
-        counterDiv.appendChild(createCountdownSpans('secs'))
+  if (timeLeft() > 0) {
+    counterDiv.appendChild(createCountdownSpans('days'))
+    counterDiv.appendChild(createCountdownSpans('hours'))
+    counterDiv.appendChild(createCountdownSpans('minutes'))
+    counterDiv.appendChild(createCountdownSpans('secs'))
 
-        // update the counter every 1 second
-        setInterval(updateCounter, 1000, counterDiv);
-    } else {
-        document.getElementById("countdown-intro").remove();
-    }
+    // update the counter every 1 second
+    setInterval(updateCounter, 1000, counterDiv);
+  } else {
+    document.getElementById("countdown-intro").remove();
+  }
 }
 
 startCountDown(counterDiv);

--- a/{{ cookiecutter.repo_directory }}/assets/js/main.js
+++ b/{{ cookiecutter.repo_directory }}/assets/js/main.js
@@ -1,39 +1,34 @@
 "use strict";
 
-/* ======= Header animation ======= */   
-const header = document.getElementById('header');  
+/* ======= Header animation ======= */
+const header = document.getElementById('header');
 
-window.onload=function() 
-{   
-    headerAnimation(); 
-
+window.onload=function()
+{
+    headerAnimation();
 };
 
-window.onresize=function() 
-{   
-    headerAnimation(); 
+window.onresize=function()
+{
+    headerAnimation();
+};
 
-}; 
+window.onscroll=function()
+{
+    headerAnimation();
+};
 
-window.onscroll=function() 
-{ 
-    headerAnimation(); 
-
-}; 
-    
 
 function headerAnimation () {
-
     var scrollTop = window.scrollY;
-	
-	if ( scrollTop > 100 ) {	    
-	    header.classList.add('header-shrink');    
-	    	    
+
+	if ( scrollTop > 100 ) {
+	    header.classList.add('header-shrink');
+
 	} else {
 	    header.classList.remove('header-shrink');
 	}
-
-};
+}
 
 /* ===== Smooth scrolling ====== */
 /*  Note: You need to include smoothscroll.min.js (smooth scroll behavior polyfill) on the page to cover some browsers */
@@ -42,34 +37,44 @@ function headerAnimation () {
 
 let scrollLinks = document.querySelectorAll('.scrollto');
 const pageNavWrapper = document.getElementById('navigation');
+const yOffset = 69; //page .header height
 
 scrollLinks.forEach((scrollLink) => {
-
 	scrollLink.addEventListener('click', (e) => {
-		
 		e.preventDefault();
 
 		let element = document.querySelector(scrollLink.getAttribute("href"));
-		
-		const yOffset = 69; //page .header height
-		
+
 		//console.log(yOffset);
-		
+
 		const y = element.getBoundingClientRect().top + window.pageYOffset - yOffset;
-		
+
 		window.scrollTo({top: y, behavior: 'smooth'});
-		
-		
+
+
 		//Collapse mobile menu after clicking
 		if (pageNavWrapper.classList.contains('show')){
 			pageNavWrapper.classList.remove('show');
 		}
-
-		
     });
-	
 });
-    
+
+// Jump to section if requested via URL 'jump_to' parameter
+
+function jumpToSection() {
+  const section = new URLSearchParams(window.location.search).get('jump_to');
+
+  if (section.length > 0) {
+    window.scrollTo({
+      top: document.getElementById(section).offsetTop + yOffset,
+      behavior: 'smooth'
+    })
+  }
+}
+
+if (window.location.search.length > 1) {
+  jumpToSection();
+}
 
 /* ===== Gumshoe SrollSpy ===== */
 /* Ref: https://github.com/cferdinandi/gumshoe  */

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -82,7 +82,7 @@
 
 							<li class="nav-item"><a class="nav-link scrollto" href="#about-section">About</a></li>
 							<li class="nav-item"><a class="nav-link scrollto" href="#team">Team</a></li>
-							<li class="nav-item"><a class="nav-link scrollto" href="#schedule-section">Schedule</a></li>
+							<li class="nav-item"><a class="nav-link scrollto" href="#schedule">Schedule</a></li>
 							<li class="nav-item"><a class="nav-link scrollto" href="#sponsors-section">Sponsors</a></li>
 						</ul>
 						<!--//nav-->
@@ -304,7 +304,7 @@
 		<hr>
 	</div>
 	{%- if cookiecutter.schedule %}
-	<section id="schedule-section" class="schedule-section section">
+	<section id="schedule" class="schedule-section section">
 		<div class="container">
 			<h3 class="section-heading text-center mb-1">Schedule</h3>
 			<h4 class="text-center mb-5"> All times listed below are {{ cookiecutter.schedule.timezone }}.


### PR DESCRIPTION
As I pointed out during our meeting yesterday, the links to the teams and schedule on the splash page weren't showing up in the Jupyterbook. The links weren't pointing specifically to the jupyter-template repo github.io page.