### PR TITLE
Use pull-request:image instead of DOCKER_IMAGE variable

### DIFF
--- a/.github/workflows/repo2docker-PR.yaml
+++ b/.github/workflows/repo2docker-PR.yaml
@@ -27,4 +27,4 @@ jobs:
       if: always()
       run: |
         docker images
-        docker run ${{secrets.DOCKER_IMAGE}}:latest conda list --export
+        docker run pull-request:latest conda list --export


### PR DESCRIPTION
Fixes an error like `docker: invalid reference format` when the secret is unavailable, or if the Pull Request is ran from forks.

Discovered this while working on https://github.com/CryoInTheCloud/CryoCloudWebsite/pull/2. Patches https://github.com/uwhackweek/jupyterbook-template/commit/d9d7e587ab703b725d496c90db938f860ae1eed2