### PR TITLE
add template sync action to repo

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -42,7 +42,7 @@
     },
     {
       "login": "JessicaS11",
-      "name": "Jessica",
+      "name": "Jessica Scheick",
       "avatar_url": "https://avatars.githubusercontent.com/u/11756442?v=4",
       "profile": "https://github.com/JessicaS11",
       "contributions": [

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -41,6 +41,8 @@ Quality assessment and quality control. Standardizes formatting including spell 
 #### [template-sync.yaml](../workflows/template-sync.yaml)
 Open a PR to update the templated repo to incorporate changes made to the
 [template repo](https://github.com/uwhackweek/jupyterbook-template).
+Template users should fill out the [.templatesyncignore](../../../.templatesyncignore)
+to specify which files they do not want updated from the template.
 
 
 ## Security

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -20,6 +20,9 @@ The `workflows/` subfolder contains continuous integration workflows
 #### [binder-badge.yaml](../workflows/binder-badge.yaml)
 Create [binder](https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html) badges with links to test tutorial notebooks
 
+#### [build-website.yaml](../workflows/build-website.yaml)
+Build the websites (JupyterBook and front page). Run on Pull Requests against every commit and via a 'cron' schedule to maintain caching [since otherwise the cache expires if untouched in 7 days](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)
+
 #### [deploy.yaml](../workflows/deploy.yaml)
 Render and publish the websites (JupyterBook and landing page) to GitHub Pages
 
@@ -39,8 +42,6 @@ Quality assessment and quality control. Standardizes formatting including spell 
 Open a PR to update the templated repo to incorporate changes made to the
 [template repo](https://github.com/uwhackweek/jupyterbook-template).
 
-#### [test.yaml](../workflows/test.yaml)
-Build the websites (JupyterBook and front page). Run on Pull Requests against every commit and via a 'cron' schedule to maintain caching [since otherwise the cache expires if untouched in 7 days](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)
 
 ## Security
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -35,6 +35,10 @@ Quality assessment and quality control. Standardizes formatting including spell 
 #### [repo2docker.yaml](../workflows/repo2docker.yaml)
 [Build a Docker image](https://github.com/jupyterhub/repo2docker-action) for JupyterHub/BinderHub
 
+#### [template-sync.yaml](../workflows/template-sync.yaml)
+Open a PR to update the templated repo to incorporate changes made to the
+[template repo](https://github.com/uwhackweek/jupyterbook-template).
+
 #### [test.yaml](../workflows/test.yaml)
 Build the websites (JupyterBook and front page). Run on Pull Requests against every commit and via a 'cron' schedule to maintain caching [since otherwise the cache expires if untouched in 7 days](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)
 

--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: cache binder build on mybinder.org
       uses: jupyterhub/repo2docker-action@master

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Configure NASA Earthdata Login
       continue-on-error: true

--- a/.github/workflows/repo2docker-PR.yaml
+++ b/.github/workflows/repo2docker-PR.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get CalenderVersion UTC Date
       id: calver

--- a/.github/workflows/repo2docker.yaml
+++ b/.github/workflows/repo2docker.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get CalenderVersion UTC Date
       id: calver

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -3,7 +3,7 @@ description: 'Get updates to the Jupyterbook from the template repo'
 
 on:
   # cronjob trigger (minute, hour, day, month, day-of-week; here 1st of month)
-  schedule:
+  # schedule:
   # - cron:  "0 0 1 * *"
   # manual trigger
   workflow_dispatch:

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -4,7 +4,7 @@ description: 'Get updates to the Jupyterbook from the template repo'
 on:
   # cronjob trigger (minute, hour, day, month, day-of-week; here 1st of month)
   schedule:
-  - cron:  "0 0 1 * *"
+  # - cron:  "0 0 1 * *"
   # manual trigger
   workflow_dispatch:
 
@@ -29,6 +29,5 @@ jobs:
         uses: AndreasAugustin/actions-template-sync@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          source_repo_path: <owner/repo>
-          upstream_branch: <target_branch> # defaults to main
-          pr_labels: <label1>,<label2>[,...] # defaults to template_sync
+          source_repo_path: uwhackweek/jupyterbook-template
+          upstream_branch: main # defaults to main

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -1,0 +1,34 @@
+name: 'Sync to Template'
+description: 'Get updates to the Jupyterbook from the template repo'
+
+on:
+  # cronjob trigger (minute, hour, day, month, day-of-week; here 1st of month)
+  schedule:
+  - cron:  "0 0 1 * *"
+  # manual trigger
+  workflow_dispatch:
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      # To use this repository's private action, you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+        # https://github.com/actions/checkout#usage
+        # uncomment if you use submodules within the source repository
+        # with:
+        #   submodules: true
+
+      - name: actions-template-sync
+        uses: AndreasAugustin/actions-template-sync@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_repo_path: <owner/repo>
+          upstream_branch: <target_branch> # defaults to main
+          pr_labels: <label1>,<label2>[,...] # defaults to template_sync

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -2,10 +2,14 @@
 # use glob patterns as in .gitignore
 # recommend listing non-basics tutorial directories here
 
+# configuration files
+cookiecutter.yaml
+
 # environment lock files
 ./conda/*lock.yml
 
-# general book files
+# book files (configuration, usage-specific)
+./book/_config.yml
 ./book/team.yaml
 
 # event-specific tutorials

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -1,0 +1,3 @@
+# THIS FILE CANNOT BE SYNCED
+# use glob patterns as in .gitignore
+# recommend listing non-basics tutorial directories here

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -1,3 +1,11 @@
 # THIS FILE CANNOT BE SYNCED
 # use glob patterns as in .gitignore
 # recommend listing non-basics tutorial directories here
+
+# environment lock files
+./conda/*lock.yml
+
+# general book files
+./book/team.yaml
+
+# event-specific tutorials

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We've found that every hackweek benefits from a single-page website to get peopl
 
 We've used this template for the following events:
 
-* ICESat-2 Hackweek 2022: https://icesat-2.hackweek.io
+* ICESat-2 Hackweek 2022 + 2023: https://icesat-2.hackweek.io
 * SnowEx Hackweek 2021: https://snowex-hackweek.github.io/website/intro.html
 
 


### PR DESCRIPTION
One of the challenges for using this template across multiple events is trying to get per-event updates that should apply to the template back into the template. So far, this heroic work has been done by @jomey and @scottyhq on a largely manual basis. This PR adds the [template-sync](https://github.com/marketplace/actions/actions-template-sync) github action that will automatically (via cron on the 1st of the month) or manually open a PR in the templated repo that incorporates the changes made to the template. This will enable template-level updates to be made and merged directly into the template and then easily incorporated into any repos that were created using the template. This will be especially useful for upcoming events that will be sharing some tutorial content.