### PR TITLE
Fix the sync-template action to work

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -43,6 +43,9 @@ Open a PR to update the templated repo to incorporate changes made to the
 [template repo](https://github.com/uwhackweek/jupyterbook-template).
 Template users should fill out the [.templatesyncignore](../../../.templatesyncignore)
 to specify which files they do not want updated from the template.
+Note that if you want the GitHub action and workflow files to be updated,
+you will need to [create a personal access token(PAT)](https://github.com/AndreasAugustin/actions-template-sync?tab=readme-ov-file#troubleshooting).
+Alternatively, you must add ".github/**" to your `.templatesyncignore` file, and your actions will not be updated.
 
 
 ## Security

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -22,7 +22,7 @@ jobs:
         # comment token (and add .github path to .templatesyncignore)
         # if you do not want actions and workflows updated
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v2
@@ -30,3 +30,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: uwhackweek/jupyterbook-template
           upstream_branch: main # defaults to main
+          is_force_deletion: True

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -19,12 +19,9 @@ jobs:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v4
-        # https://github.com/actions/checkout#usage
-        # uncomment if you use submodules within the source repository
         # comment token (and add .github path to .templatesyncignore)
         # if you do not want actions and workflows updated
         with:
-        #   submodules: true
           token: ${{ secrets.GH_PAT }}
 
       - name: actions-template-sync

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -1,5 +1,4 @@
 name: 'Sync to Template'
-description: 'Get updates to the Jupyterbook from the template repo'
 
 on:
   # cronjob trigger (minute, hour, day, month, day-of-week; here 1st of month)
@@ -22,11 +21,14 @@ jobs:
         uses: actions/checkout@v4
         # https://github.com/actions/checkout#usage
         # uncomment if you use submodules within the source repository
-        # with:
+        # comment token (and add .github path to .templatesyncignore)
+        # if you do not want actions and workflows updated
+        with:
         #   submodules: true
+          token: ${{ secrets.GH_PAT }}
 
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@v1
+        uses: AndreasAugustin/actions-template-sync@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: uwhackweek/jupyterbook-template

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -1,15 +1,17 @@
 # THIS FILE CANNOT BE SYNCED
 # use glob patterns as in .gitignore
 # recommend listing non-basics tutorial directories here
-
+###
 # configuration files
 cookiecutter.yaml
-
+###
 # environment lock files
-./conda/*lock.yml
-
+conda/*lock.yml
+###
+# team member files
+team/*-*
+###
 # book files (configuration, usage-specific)
-./book/_config.yml
-./book/team.yaml
-
+book/_config.yml
+###
 # event-specific tutorials

--- a/team/README.md
+++ b/team/README.md
@@ -8,7 +8,7 @@ Follow these steps to add yourself:
 * Use the provided 'template.yaml' file and copy the file.
 * Create a copy of the 'template.yaml' file and rename the file to your name
    ```
-    cp template.yaml FirstName_LastName.yaml
+    cp template.yaml FirstName-LastName.yaml
    ```
 * Open the new file you just created in your favorite editor and fill out the
   details, replacing the placeholder text.


### PR DESCRIPTION
After all the great additions last week, I tested the sync-to-template action on the [tester repo](https://github.com/ICESAT-2HackWeek/jupyterbook-template-tester). I ended up finding a few issues, fixed herein, as well as discovered a [minor bug](https://github.com/AndreasAugustin/actions-template-sync/issues/510) in the action itself. The PR opened by the action: https://github.com/ICESAT-2HackWeek/jupyterbook-template-tester/pull/2

A couple decision points:
- [x] Currently, we have `cookiecutter.yaml` as one of our excluded files because it gets filled in with event info. But, it got updated in the last week's edits. I'm inclined to think the case where an excluded file is updated is not worth a custom solution (it would be easy enough to simply edit or delete the `.templatesyncignore` file in the templated repo and run the action to open a PR with any changes). Thoughts? UPDATE: make any such changes manually or by triggering the update action from a branch with a modified `.templatesyncignore` file.
- [x] There is a flag in the action to check for existing, open PRs created by the action and "clean them up" (it's recommended to use with caution). Should we leave the default for now (which won't clean them up; I'm not sure if a new PR will be opened or it will just exit, with or without error)? UPDATE: we tried the `is_pr_cleanup` flag and it did not modify the open PR, just exited the action since the branch existed, so we're leaving as default.