### PR TITLE
use personal access token instead of GH token

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -31,3 +31,4 @@ jobs:
           source_repo_path: uwhackweek/jupyterbook-template
           upstream_branch: main # defaults to main
           is_force_deletion: True
+          git_remote_pull_params: --allow-unrelated-histories --squash --strategy=recursive -X theirs

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -22,7 +22,7 @@ jobs:
         # comment token (and add .github path to .templatesyncignore)
         # if you do not want actions and workflows updated
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v2


### PR DESCRIPTION
Following up on #159, a PAT (not GH) token is required. Also, we missed some required parameters.

@jomey It looks like the updates are commit based (presumably IDed based on commit timestamps), and the most recent commit in the template repo is used as the branch ID in the PR opened to the templated repo. As a result (1) we didn't see any changes to our open PR with the `is_pr_cleanup` because that was still the most recent commit in the template repo; (2) even though we added `is_force_deletion: True` a new run doesn't pick up the deleted files (because I'd merged the previous round of updates in).