### PR TITLE
update team readme instructions

### DIFF
--- a/team/README.md
+++ b/team/README.md
@@ -10,7 +10,7 @@ Follow these steps to add yourself:
 * Use the provided 'template.yaml' file.
 * Create a copy of the 'template.yaml' file and rename the file to your name.
 In the GitHub interface, you can create a new file and copy-paste from the template.
-Or, in a local copy of the repository you can do this on the command line with
+Or, in a local repository you can do this on the command line with
    ```
     cp template.yaml FirstName-LastName.yaml
    ```

--- a/team/README.md
+++ b/team/README.md
@@ -10,7 +10,7 @@ Follow these steps to add yourself:
 * Use the provided 'template.yaml' file.
 * Create a copy of the 'template.yaml' file and rename the file to your name.
 In the GitHub interface, you can create a new file and copy-paste from the template.
-Or, you can do this on the command line with
+Or, in a local copy of the repository you can do this on the command line with
    ```
     cp template.yaml FirstName-LastName.yaml
    ```

--- a/team/README.md
+++ b/team/README.md
@@ -9,7 +9,8 @@ Follow these steps to add yourself:
 * Navigate into the 'teams' directory.
 * Use the provided 'template.yaml' file.
 * Create a copy of the 'template.yaml' file and rename the file to your name.
-In the GitHub interface, you can create a new file and copy-paste from the template. Or, you can do this on the command line with
+In the GitHub interface, you can create a new file and copy-paste from the template.
+Or, you can do this on the command line with
    ```
     cp template.yaml FirstName-LastName.yaml
    ```

--- a/team/README.md
+++ b/team/README.md
@@ -9,7 +9,7 @@ Follow these steps to add yourself:
 * Navigate into the 'teams' directory.
 * Use the provided 'template.yaml' file.
 * Create a copy of the 'template.yaml' file and rename the file to your name.
-You can do this through the GitHub interface, your local development environment, or on the command line with
+In the GitHub interface, you can create a new file and copy-paste from the template. Or, you can do this on the command line with
    ```
     cp template.yaml FirstName-LastName.yaml
    ```

--- a/team/README.md
+++ b/team/README.md
@@ -1,16 +1,20 @@
 # The team folder
 
-All members of the organizing team should add themselves to the webpage and
-this folder contains a file for each person describing themselves.
+All members of the organizing team should add themselves to the webpage.
+This folder contains a file for each person describing themselves.
 
 ## Adding a new member
 Follow these steps to add yourself:
-* Use the provided 'template.yaml' file and copy the file.
-* Create a copy of the 'template.yaml' file and rename the file to your name
+* Navigate to the 'landing page' repository for your event.
+* Navigate into the 'teams' directory.
+* Use the provided 'template.yaml' file.
+* Create a copy of the 'template.yaml' file and rename the file to your name.
+You can do this through the GitHub interface, your local development environment, or on the command line with
    ```
     cp template.yaml FirstName-LastName.yaml
    ```
 * Open the new file you just created in your favorite editor and fill out the
   details, replacing the placeholder text.
-* Commit the file and open a pull request
-* Don't forget to add a reviewer to the pull request so they get notified.
+* Commit the file and (if necessary) push your changes to GitHub.
+* Open a pull request (PR).
+* Don't forget to add a reviewer to the PR so they get notified.


### PR DESCRIPTION
Update the instructions for adding oneself to the team page (originally [here](https://github.com/uwhackweek/hackweeks-as-a-service/pull/62/commits/23590cf51a5da0c5963e7001de53b2f218ae43ad)). Our guidebook directs organizers to these instructions for adding themselves as a team member on the event page.