### PR TITLE
Update _config.yml

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -63,6 +63,7 @@ bibtex_bibfiles:
 sphinx:
   config:
     bibtex_reference_style: author_year  # or label, super, \supercite
+    nb_merge_streams: true # stdout lines combined in output
     nb_custom_formats:
         .py:
             - jupytext.reads


### PR DESCRIPTION
for the PACE hackweek book, we had the problem that output from bash cells (using `%%bash`) were being broken into multiple cells. We added this to create the merged cells like you see when you open a jupyter notebook.